### PR TITLE
WC deprecations & Ignore URLs with get requests

### DIFF
--- a/build/plugin-compatibility/woocommerce.php
+++ b/build/plugin-compatibility/woocommerce.php
@@ -33,10 +33,10 @@ function quicklink_woocommerce_compatibility( $options ) {
 	}
 
 	// Do not preload the cart, as it is usally ressource heavy.
-	$wc_ignores[] = '^' . preg_quote( get_cart_url(), '/' );
+	$wc_ignores[] = '^' . preg_quote( wc_get_cart_url(), '/' );
 
 	// Do not preload the checkout url for the same reason as above.
-	$wc_ignores[] = '^' . preg_quote( get_checkout_url(), '/' );
+	$wc_ignores[] = '^' . preg_quote( wc_get_checkout_url(), '/' );
 
 	// Do not preload the 'Payment' page, as it is usually ressource heavy.
 	if ( wc_get_page_id( 'pay' ) ) {

--- a/build/plugin-compatibility/woocommerce.php
+++ b/build/plugin-compatibility/woocommerce.php
@@ -26,12 +26,6 @@ function quicklink_woocommerce_compatibility( $options ) {
 		return $options;
 	}
 
-	// Do not preload 'add to cart' links.
-	$wc_ignores[] = preg_quote( 'add-to-cart=', '/' );
-
-	// Do not preload 'add to wishlist' links.
-	$wc_ignores[] = preg_quote( 'add_to_wishlist=', '/' );
-
 	// Do not preload the 'my account' page, as it is usually ressource heavy.
 	$myaccount_page_id = get_option( 'woocommerce_myaccount_page_id' );
 	if ( $myaccount_page_id ) {

--- a/build/plugin-compatibility/woocommerce.php
+++ b/build/plugin-compatibility/woocommerce.php
@@ -29,6 +29,9 @@ function quicklink_woocommerce_compatibility( $options ) {
 	// Do not preload 'add to cart' links.
 	$wc_ignores[] = preg_quote( 'add-to-cart=', '/' );
 
+	// Do not preload 'add to wishlist' links.
+	$wc_ignores[] = preg_quote( 'add_to_wishlist=', '/' );
+
 	// Do not preload the 'my account' page, as it is usually ressource heavy.
 	$myaccount_page_id = get_option( 'woocommerce_myaccount_page_id' );
 	if ( $myaccount_page_id ) {
@@ -36,14 +39,14 @@ function quicklink_woocommerce_compatibility( $options ) {
 	}
 
 	// Do not preload the cart, as it is usally ressource heavy.
-	$wc_ignores[] = '^' . preg_quote( $woocommerce->cart->get_cart_url(), '/' );
+	$wc_ignores[] = '^' . preg_quote( get_cart_url(), '/' );
 
 	// Do not preload the checkout url for the same reason as above.
-	$wc_ignores[] = '^' . preg_quote( $woocommerce->cart->get_checkout_url(), '/' );
+	$wc_ignores[] = '^' . preg_quote( get_checkout_url(), '/' );
 
 	// Do not preload the 'Payment' page, as it is usually ressource heavy.
-	if ( woocommerce_get_page_id( 'pay' ) ) {
-		$wc_ignores[] = '^' . preg_quote( get_permalink( woocommerce_get_page_id( 'pay' ) ), '/' );
+	if ( wc_get_page_id( 'pay' ) ) {
+		$wc_ignores[] = '^' . preg_quote( get_permalink( wc_get_page_id( 'pay' ) ), '/' );
 	}
 
 	// Remove possible empty strings and duplicates from the array.

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -73,7 +73,7 @@ function quicklink_enqueue_scripts() {
 			preg_quote( wp_parse_url( content_url(), PHP_URL_PATH ), '/' ),
 
 			// Do not preload links with get parameters.
-			'.*\?((.*=.*)(&?))+',
+			'.*\?.+',
 		),
 	);
 

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -71,6 +71,9 @@ function quicklink_enqueue_scripts() {
 
 			// Do not preload wp-content items (like downloads).
 			preg_quote( wp_parse_url( content_url(), PHP_URL_PATH ), '/' ),
+
+			// Do not preload links with get parameters.
+			'.*\?((.*=.*)(&?))+',
 		),
 	);
 


### PR DESCRIPTION
This PR updates some function names for WooCommerce, which are deprecated. 

We also change the ignore default to ignore URLs with get requests, as they tend to complicate things. ( e.g. `http://localhost/?add-to-cart=18`)

fixes #21