### PR TITLE
Remove deprecated functions, for which no (elegant) replacement exists

### DIFF
--- a/build/plugin-compatibility/woocommerce.php
+++ b/build/plugin-compatibility/woocommerce.php
@@ -38,11 +38,6 @@ function quicklink_woocommerce_compatibility( $options ) {
 	// Do not preload the checkout url for the same reason as above.
 	$wc_ignores[] = '^' . preg_quote( wc_get_checkout_url(), '/' );
 
-	// Do not preload the 'Payment' page, as it is usually ressource heavy.
-	if ( wc_get_page_id( 'pay' ) ) {
-		$wc_ignores[] = '^' . preg_quote( get_permalink( wc_get_page_id( 'pay' ) ), '/' );
-	}
-
 	// Remove possible empty strings and duplicates from the array.
 	$wc_ignores = array_unique( array_filter( $wc_ignores ) );
 


### PR DESCRIPTION
We were still generating deprecation notices with WooCommerce