### PR TITLE
Update quicklink to version 2.0

### DIFF
--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -1,49 +1,59 @@
-import { listen } from 'quicklink';
+import { listen, prefetch } from 'quicklink';
 
 window.addEventListener( 'load', () => {
 	const exportedOptions = window.quicklinkOptions || {};
 
-	const options = {};
+	const listenerOptions = {};
 
 	// el: Convert selector into element reference.
 	if ( 'string' === typeof exportedOptions.el && exportedOptions.el ) {
-		options.el = document.querySelector( exportedOptions.el );
-	}
-
-	// urls: Verify we don't get an empty array, as that would turn off quicklink.
-	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
-		options.urls = exportedOptions.urls;
+		listenerOptions.el = document.querySelector( exportedOptions.el );
 	}
 
 	// timeout: Verify we actually get an int for milliseconds.
 	if ( 'number' === typeof exportedOptions.timeout ) {
-		options.timeout = exportedOptions.timeout;
+		listenerOptions.timeout = exportedOptions.timeout;
+	}
+
+	// limit: Verify we actually get an int.
+	if ( 'number' === typeof exportedOptions.limit ) {
+		listenerOptions.limit = exportedOptions.limit;
+	}
+
+	// throttle: Verify we actually get an int.
+	if ( 'number' === typeof exportedOptions.throttle ) {
+		listenerOptions.throttle = exportedOptions.throttle;
 	}
 
 	// timeoutFn: Obtain function reference as opposed to function string, if it is not the default.
 	if ( 'string' === typeof exportedOptions.timeoutFn && 'requestIdleCallback' !== exportedOptions.timeoutFn ) {
 		const timeoutFn = window[ exportedOptions.timeoutFn ];
-		options.timeoutFn = function() {
+		listenerOptions.timeoutFn = function() {
 			return timeoutFn.apply( window, arguments );
 		};
 	}
 
 	// priority: Obtain priority.
 	if ( 'boolean' === typeof exportedOptions.priority ) {
-		options.priority = exportedOptions.priority;
+		listenerOptions.priority = exportedOptions.priority;
 	}
 
 	// origins: Verify we don't get an empty array, as that would turn off quicklink.
 	if ( Array.isArray( exportedOptions.origins ) && 0 < exportedOptions.origins.length ) {
-		options.origins = exportedOptions.origins;
+		listenerOptions.origins = exportedOptions.origins;
 	}
 
 	// ignores: Convert strings to regular expressions.
 	if ( Array.isArray( exportedOptions.ignores ) && 0 < exportedOptions.ignores.length ) {
-		options.ignores = exportedOptions.ignores.map( ( ignore ) => {
+		listenerOptions.ignores = exportedOptions.ignores.map( ( ignore ) => {
 			return new RegExp( ignore );
 		} );
 	}
 
-	listen( options );
+	listen( listenerOptions );
+
+	// urls: Verify we don't get an empty array, as that would turn off quicklink.
+	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
+		prefetch( exportedOptions.urls );
+	}
 } );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -1,4 +1,4 @@
-import quicklink from 'quicklink/dist/quicklink.mjs';
+import { listen } from 'quicklink';
 
 window.addEventListener( 'load', () => {
 	const exportedOptions = window.quicklinkOptions || {};
@@ -45,5 +45,5 @@ window.addEventListener( 'load', () => {
 		} );
 	}
 
-	quicklink( options );
+	listen( options );
 } );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -55,6 +55,9 @@ window.addEventListener( 'load', () => {
 
 	quicklink.listen( listenerOptions );
 
+	/**
+	 * The option to prefetch urls from the options is deprecated as of version 0.8.0.
+	 */
 	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
 		quicklink.prefetch( exportedOptions.urls );
 	}

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -1,4 +1,7 @@
-import { listen, prefetch } from 'quicklink';
+import * as quicklink from 'quicklink';
+
+// Move quicklink to the global scope
+window.quicklink = quicklink;
 
 window.addEventListener( 'load', () => {
 	const exportedOptions = window.quicklinkOptions || {};
@@ -50,9 +53,9 @@ window.addEventListener( 'load', () => {
 		} );
 	}
 
-	listen( listenerOptions );
+	quicklink.listen( listenerOptions );
 
 	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
-		prefetch( exportedOptions.urls );
+		quicklink.prefetch( exportedOptions.urls );
 	}
 } );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -5,7 +5,6 @@ window.quicklink = quicklink;
 
 window.addEventListener( 'load', () => {
 	const exportedOptions = window.quicklinkOptions || {};
-	const prefetchQueue = window.quicklinkPrefetch || {};
 
 	const listenerOptions = {};
 
@@ -69,14 +68,5 @@ window.addEventListener( 'load', () => {
 	 */
 	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
 		quicklink.prefetch( exportedOptions.urls );
-	}
-
-	/**
-	 * Handle the prefetch queue.
-	 */
-	if ( Array.isArray( prefetchQueue ) ) {
-		for ( const { url, isPriority } of prefetchQueue ) {
-			quicklink.prefetch( url, isPriority );
-		}
 	}
 } );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -38,7 +38,7 @@ window.addEventListener( 'load', () => {
 	}
 
 	// onError: Obtain function reference as opposed to function string, if it is not the default.
-	if ( 'string' === typeof exportedOptions.onError && 'requestIdleCallback' !== exportedOptions.onError && typeof 'function' === window[ exportedOptions.onError ] ) {
+	if ( 'string' === typeof exportedOptions.onError && typeof 'function' === window[ exportedOptions.onError ] ) {
 		const onError = window[ exportedOptions.onError ];
 		listenerOptions.onError = function() {
 			return onError.apply( window, arguments );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -37,6 +37,14 @@ window.addEventListener( 'load', () => {
 		};
 	}
 
+	// onError: Obtain function reference as opposed to function string, if it is not the default.
+	if ( 'string' === typeof exportedOptions.onError && 'requestIdleCallback' !== exportedOptions.onError && typeof 'function' === window[ exportedOptions.onError ] ) {
+		const onError = window[ exportedOptions.onError ];
+		listenerOptions.onError = function() {
+			return onError.apply( window, arguments );
+		};
+	}
+
 	// priority: Obtain priority.
 	if ( 'boolean' === typeof exportedOptions.priority ) {
 		listenerOptions.priority = exportedOptions.priority;

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -21,12 +21,12 @@ window.addEventListener( 'load', () => {
 	}
 
 	// throttle: Verify we actually get an int.
-	if ( 'number' === typeof exportedOptions.throttle ) {
+	if ( 'number' === typeof exportedOptions.throttle && exportedOptions.throttle > 0 ) {
 		listenerOptions.throttle = exportedOptions.throttle;
 	}
 
 	// timeoutFn: Obtain function reference as opposed to function string, if it is not the default.
-	if ( 'string' === typeof exportedOptions.timeoutFn && 'requestIdleCallback' !== exportedOptions.timeoutFn ) {
+	if ( 'string' === typeof exportedOptions.timeoutFn && 'requestIdleCallback' !== exportedOptions.timeoutFn && typeof 'function' === window[ exportedOptions.timeoutFn ] ) {
 		const timeoutFn = window[ exportedOptions.timeoutFn ];
 		listenerOptions.timeoutFn = function() {
 			return timeoutFn.apply( window, arguments );
@@ -52,7 +52,6 @@ window.addEventListener( 'load', () => {
 
 	listen( listenerOptions );
 
-	// urls: Verify we don't get an empty array, as that would turn off quicklink.
 	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
 		prefetch( exportedOptions.urls );
 	}

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -5,6 +5,7 @@ window.quicklink = quicklink;
 
 window.addEventListener( 'load', () => {
 	const exportedOptions = window.quicklinkOptions || {};
+	const prefetchQueue = window.quicklinkPrefetch || {};
 
 	const listenerOptions = {};
 
@@ -60,5 +61,14 @@ window.addEventListener( 'load', () => {
 	 */
 	if ( Array.isArray( exportedOptions.urls ) && 0 < exportedOptions.urls.length ) {
 		quicklink.prefetch( exportedOptions.urls );
+	}
+
+	/**
+	 * Handle the prefetch queue.
+	 */
+	if ( Array.isArray( prefetchQueue ) ) {
+		for ( const { url, isPriority } of prefetchQueue ) {
+			quicklink.prefetch( url, isPriority );
+		}
 	}
 } );

--- a/build/js/quicklink.js
+++ b/build/js/quicklink.js
@@ -16,7 +16,7 @@ window.addEventListener( 'load', () => {
 	}
 
 	// limit: Verify we actually get an int.
-	if ( 'number' === typeof exportedOptions.limit ) {
+	if ( 'number' === typeof exportedOptions.limit && exportedOptions.limit > 0 ) {
 		listenerOptions.limit = exportedOptions.limit;
 	}
 

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -179,7 +179,7 @@ add_action( 'init', 'quicklink_plugin_compatibility_files' );
  * @return void
  */
 function quicklink_to_default_scripts( $scripts ) {
-	$scripts->add( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
+	$scripts->add( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>' );
 }
 add_action( 'wp_default_scripts', 'quicklink_to_default_scripts' );
 

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -116,6 +116,27 @@ function quicklink_enqueue_scripts() {
 		sprintf( 'var quicklinkOptions = %s;', wp_json_encode( $options ) ),
 		'before'
 	);
+
+	/**
+	 * Filters URLs to be prefetched by quicklink
+	 *
+	 * @link https://getquick.link/api/
+	 * @param array[] {
+	 *     An array of urls to be prefetched.
+	 *
+	 *     @param string $url An URL to be prefetched.
+	 *     @param bool   $isPriority Whether or not the URL should be treaded as high priority target.
+	 * }
+	 */
+	$prefetch = apply_filters( 'quicklink_prefetch', array() );
+
+	if ( is_array( $prefetch ) && ! empty( $prefetch ) ) {
+		wp_add_inline_script(
+			'quicklink',
+			sprintf( 'var quicklinkPrefetch = %s;', wp_json_encode( $prefetch ) ),
+			'before'
+		);
+	}
 }
 add_action( 'wp_enqueue_scripts', 'quicklink_enqueue_scripts' );
 
@@ -161,3 +182,25 @@ function quicklink_to_default_scripts( $scripts ) {
 	$scripts->add( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
 }
 add_action( 'wp_default_scripts', 'quicklink_to_default_scripts' );
+
+/**
+ * Prefetch a url with quicklink.
+ *
+ * @param  string  $url         The URL to be prefetched.
+ * @param  boolean $is_priority Whether or not the URL should be treaded as high priority target.
+ *
+ * @return void
+ */
+function quicklink_prefetch( $url, $is_priority = false ) {
+	add_filter(
+		'quicklink_prefetch',
+		function( $prefetch ) use ( $url, $is_priority ) {
+			$prefetch[] = array(
+				'url'        => $url,
+				'isPriority' => $is_priority,
+			);
+
+			return $prefetch;
+		}
+	);
+}

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -31,7 +31,7 @@ function quicklink_enqueue_scripts() {
 		return;
 	}
 
-	wp_enqueue_script( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
+	wp_enqueue_script( 'quicklink' );
 
 	$options = array(
 		// CSS selector for the DOM element to observe for in-viewport links to prefetch.
@@ -136,3 +136,15 @@ function quicklink_plugin_compatibility_files() {
 	}
 }
 add_action( 'init', 'quicklink_plugin_compatibility_files' );
+
+/**
+ * Add quicklink to the default scripts to make it available earlier in the runtime.
+ *
+ * @param WP_Scripts $scripts The WP_Scripts instance.
+ *
+ * @return void
+ */
+function quicklink_to_default_scripts( $scripts ) {
+	$scripts->add( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
+}
+add_action( 'wp_default_scripts', 'quicklink_to_default_scripts' );

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -37,7 +37,7 @@ function quicklink_enqueue_scripts() {
 		// CSS selector for the DOM element to observe for in-viewport links to prefetch.
 		'el'        => '',
 
-		// Static array of URLs to prefetch.
+		// Static array of URLs to prefetch. Deprecated since plugin version 0.8.0.
 		'urls'      => array(),
 
 		// Integer for the `requestIdleCallback` timeout. A time in milliseconds by which the browser must execute prefetching. Defaults to 2 seconds.
@@ -93,10 +93,23 @@ function quicklink_enqueue_scripts() {
 	 *     @param string[] $origins   Allowed origins to prefetch (empty allows all). Defaults to host for current home URL.
 	 *     @param string[] $ignores   Regular expression patterns to determine whether a URL is ignored. Runs after origin checks.
 	 *     @param string   $onError   Custom error handler. Must refer to a named global function in JS.
-	 *     @param string[] $urls      Array of URLs to prefetch.
+	 *     @param string[] $urls      Array of URLs to prefetch. Deprecated as of plugin version 0.8.0
 	 * }
 	 */
 	$options = apply_filters( 'quicklink_options', $options );
+
+	/**
+	 * Add a deprecation warning for the $options[urls] option.
+	 *
+	 * @since 0.8.0
+	 */
+	if ( isset( $options['urls'] ) && ! empty( $options['urls'] ) ) {
+		_deprecated_argument(
+			__FUNCTION__,
+			'0.8.0',
+			esc_attr( __( 'The "URLs" argument has been deprecated in favor of the dedicated `quicklink_prefetch` filter.', 'quicklink' ) )
+		);
+	}
 
 	wp_add_inline_script(
 		'quicklink',

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -107,7 +107,7 @@ function quicklink_enqueue_scripts() {
 		_deprecated_argument(
 			__FUNCTION__,
 			'0.8.0',
-			esc_attr( __( 'The "URLs" argument has been deprecated in favor of the dedicated `quicklink_prefetch` filter.', 'quicklink' ) )
+			esc_attr( __( 'The "urls" argument has been deprecated in favor of the dedicated `quicklink_prefetch()` function.', 'quicklink' ) )
 		);
 	}
 

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -37,7 +37,7 @@ function quicklink_enqueue_scripts() {
 		// CSS selector for the DOM element to observe for in-viewport links to prefetch.
 		'el'        => '',
 
-		// Static array of URLs to prefetch (instead of observing `document` or a DOM element links in the viewport).
+		// Static array of URLs to prefetch.
 		'urls'      => array(),
 
 		// Integer for the `requestIdleCallback` timeout. A time in milliseconds by which the browser must execute prefetching. Defaults to 2 seconds.
@@ -83,13 +83,15 @@ function quicklink_enqueue_scripts() {
 	 * @param array {
 	 *     Configuration options for Quicklink.
 	 *
-	 *     @param string[] $urls      Array of URLs to prefetch (override).
-	 *     @param string   $el        CSS selector for the DOM element to prefetch in-viewport links for.
+	 *     @param string   $el        CSS selector for the DOM element to observe for in-viewport links to prefetch.
+	 *     @param int      $limit     The total requests that can be prefetched while observing the $el container.
+	 *     @param int      $throttle  The concurrency limit for simultaneous requests while observing the $el container.
+	 *     @param int      $timeout   Timeout after which prefetching will occur.
+	 *     @param string   $timeoutFn Custom timeout function.
 	 *     @param bool     $priority  Attempt higher priority fetch (low or high). Default false.
 	 *     @param string[] $origins   Allowed origins to prefetch (empty allows all). Defaults to host for current home URL.
 	 *     @param string[] $ignores   Regular expression patterns to determine whether a URL is ignored. Runs after origin checks.
-	 *     @param int      $timeout   Timeout after which prefetching will occur.
-	 *     @param string   $timeoutFn Custom timeout function.
+	 *     @param string[] $urls      Array of URLs to prefetch.
 	 * }
 	 */
 	$options = apply_filters( 'quicklink_options', $options );

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -80,6 +80,7 @@ function quicklink_enqueue_scripts() {
 	/**
 	 * Filters Quicklink options.
 	 *
+	 * @link https://getquick.link/api/
 	 * @param array {
 	 *     Configuration options for Quicklink.
 	 *
@@ -87,10 +88,11 @@ function quicklink_enqueue_scripts() {
 	 *     @param int      $limit     The total requests that can be prefetched while observing the $el container.
 	 *     @param int      $throttle  The concurrency limit for simultaneous requests while observing the $el container.
 	 *     @param int      $timeout   Timeout after which prefetching will occur.
-	 *     @param string   $timeoutFn Custom timeout function.
+	 *     @param string   $timeoutFn Custom timeout function. Must refer to a named global function in JS.
 	 *     @param bool     $priority  Attempt higher priority fetch (low or high). Default false.
 	 *     @param string[] $origins   Allowed origins to prefetch (empty allows all). Defaults to host for current home URL.
 	 *     @param string[] $ignores   Regular expression patterns to determine whether a URL is ignored. Runs after origin checks.
+	 *     @param string   $onError   Custom error handler. Must refer to a named global function in JS.
 	 *     @param string[] $urls      Array of URLs to prefetch.
 	 * }
 	 */

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -187,7 +187,7 @@ add_action( 'wp_default_scripts', 'quicklink_to_default_scripts' );
  * Prefetch a url with quicklink.
  *
  * @param  string  $url         The URL to be prefetched.
- * @param  boolean $is_priority Whether or not the URL should be treaded as high priority target.
+ * @param  boolean $is_priority Whether or not the URL should be treated as high priority target.
  *
  * @return void
  */

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -31,7 +31,7 @@ function quicklink_enqueue_scripts() {
 		return;
 	}
 
-	wp_enqueue_script( 'quicklink' );
+	wp_enqueue_script( 'quicklink', '', array(), false, true );
 
 	$options = array(
 		// CSS selector for the DOM element to observe for in-viewport links to prefetch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9850,10 +9850,14 @@
       "dev": true
     },
     "quicklink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/quicklink/-/quicklink-1.0.1.tgz",
-      "integrity": "sha512-XeHOnjh9WZKVvVdkDraArYPAbDg4VWnlzscXNUcPMiJCk1aGFwE/JOFKqdnKaChWGnmYcnKCFCbep0t8U4KbOw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quicklink/-/quicklink-2.0.0.tgz",
+      "integrity": "sha512-jdWCd4JlR0jxSgLgB0kJJjuwjUNWMKzepnuWV4jYzV1FnesWofzVhwonLBCRQ9NJWZ0jl44t8oUDepOYdquCtA==",
+      "dev": true,
+      "requires": {
+        "route-manifest": "^1.0.0",
+        "throttles": "^1.0.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10200,6 +10204,12 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexparam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-1.3.0.tgz",
+      "integrity": "sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g==",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -10727,6 +10737,15 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "route-manifest": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/route-manifest/-/route-manifest-1.0.0.tgz",
+      "integrity": "sha512-qn0xJr4nnF4caj0erOLLAHYiNyzqhzpUbgDQcEHrmBoG4sWCDLnIXLH7VccNSxe9cWgbP2Kw/OjME+eH3CeRSA==",
+      "dev": true,
+      "requires": {
+        "regexparam": "^1.3.0"
       }
     },
     "run-async": {
@@ -11765,6 +11784,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throttles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttles/-/throttles-1.0.1.tgz",
+      "integrity": "sha512-fab7Xg+zELr9KOv4fkaBoe/b3L0GMGLd0IBSCn16GoE/Qx6/OfCr1eGNyEcDU2pUA79qQfZ8kPQWlRuok4YwTw==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-shell": "^3.0.1",
     "grunt-webpack": "^3.1.3",
     "jit-grunt": "^0.10.0",
-    "quicklink": "^1.0.1",
+    "quicklink": "^2.0.0",
     "release-it": "^12.4.1",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.40.2",


### PR DESCRIPTION
What this PR does: 

1. Update the dependencies to include quicklink 2.0
2. Update the PHPdoc for the quicklink filter to account for the changes
3. Update the option formatting in JavaScript to account for the two new options (limit, throttle) and move the URLs option to the new `prefetch` function.